### PR TITLE
swizzle the actions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,10 +2,6 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/update_dates.yml
+++ b/.github/workflows/update_dates.yml
@@ -31,3 +31,13 @@ jobs:
       - name: create PR if changes exist
         if:  ${{ env.HAVE_CHANGES == 1 }}
         uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Upload artifact
+        if:  ${{ env.HAVE_CHANGES == 1 }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        if:  ${{ env.HAVE_CHANGES == 1 }}
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
So we expected the commit action to cause the publish action to trigger....but [because everything is terrible](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs) I suppose this won't work.

So then we change this so that we just try and run the steps to publish here, gated on the changed flag. :crossed_fingers: 